### PR TITLE
Update prsetup.h

### DIFF
--- a/prsetup.h
+++ b/prsetup.h
@@ -51,7 +51,7 @@
 #endif
 
 #ifndef ABS
-#define ABS(x)		((x)<0?(-x):(x))
+#define ABS(x)		((x)<0?(-(x)):(x))
 #endif
 
 #endif


### PR DESCRIPTION
I have fixed a potential bug if macro ABS is used with an expression. 
