### PR TITLE
ensure that nested destination paths are created via make -p

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -275,7 +275,7 @@ install-binaries: $(LIB) $(PROGS)
 	    do \
 	    if [ ! -d $$i ] ; then \
 		echo "Making directory $$i"; \
-		mkdir $$i; \
+		mkdir -p $$i; \
 		chmod 755 $$i; \
 		else true; \
 		fi; \
@@ -297,7 +297,7 @@ install-binaries: $(LIB) $(PROGS)
 install-man:
 	@if [ ! -d $(MAN_INSTALL_DIR) ] ; then \
 	    echo "Making directory $(MAN_INSTALL_DIR)"; \
-	    mkdir $(MAN_INSTALL_DIR); \
+	    mkdir -p $(MAN_INSTALL_DIR); \
 	    chmod 755 $(MAN_INSTALL_DIR); \
 	    else true; \
 	fi;
@@ -308,7 +308,7 @@ install-man:
 		M="$(MAN_INSTALL_DIR)/man$$E"; \
 		if [ ! -d $$M ] ; then \
 		    echo "Making directory $$M"; \
-		    mkdir $$M; \
+		    mkdir -p $$M; \
 		    chmod 755 $$M; \
 		    else true; \
 		fi; \
@@ -462,7 +462,7 @@ configure:	configure.ac
 
 dist:   	configure
 		($(RM) -r $(DISTDIR); \
-		mkdir $(DISTDIR); \
+		mkdir -p $(DISTDIR); \
 		cp -p *.[ch] *.tcl $(DISTDIR)/.; \
 		cp -p pkgIndex.tcl $(DISTDIR)/.; \
 		cp -p Makefile.in $(DISTDIR)/.; \


### PR DESCRIPTION
If a destination path consists of a deep hierarchy which doesn't all exist, some parts of the installation will fail because `make` rather than `make -p` is used to create the destination directories.  For example:

```
% ./configure --prefix=$PWD/a/b/c/d
[....]
% make install
[...]
Making directory /tmp/xpa-2.1.18/a/b/c/d/lib
mkdir: cannot create directory `/tmp/xpa-2.1.18/a/b/c/d/lib': No such file or directory
chmod: cannot access `/tmp/xpa-2.1.18/a/b/c/d/lib': No such file or directory
Making directory /tmp/xpa-2.1.18/a/b/c/d/include
mkdir: cannot create directory `/tmp/xpa-2.1.18/a/b/c/d/include': No such file or directory
chmod: cannot access `/tmp/xpa-2.1.18/a/b/c/d/include': No such file or directory
Making directory /tmp/xpa-2.1.18/a/b/c/d/bin
mkdir: cannot create directory `/tmp/xpa-2.1.18/a/b/c/d/bin': No such file or directory
chmod: cannot access `/tmp/xpa-2.1.18/a/b/c/d/bin': No such file or directory
Makefile:274: recipe for target 'install-binaries' failed
make: *** [install-binaries] Error 1
```
This commit adds the `-p` flag where appropriate.